### PR TITLE
docs: improve README header layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
   </picture>
 </div>
 
-
-
-----
+---
 
 <div align="center">
   <a href="https://www.apodex.ai"><img alt="Online Service" src="https://img.shields.io/badge/🤖%20Online_Service-Apodex_1.1-1783ff"/></a>

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 ---
 
+<br>
+
 <div align="center">
   <a href="https://www.apodex.ai"><img alt="Online Service" src="https://img.shields.io/badge/🤖%20Online_Service-Apodex_1.1-1783ff"/></a>
   <a href="https://www.apodex.com/"><img alt="Homepage" src="https://img.shields.io/badge/Homepage-Apodex_AI-white"/></a>

--- a/README.md
+++ b/README.md
@@ -4,10 +4,15 @@
   </picture>
 </div>
 
+
+
+----
+
 <div align="center">
   <a href="https://www.apodex.ai"><img alt="Online Service" src="https://img.shields.io/badge/🤖%20Online_Service-Apodex_1.1-1783ff"/></a>
   <a href="https://www.apodex.com/"><img alt="Homepage" src="https://img.shields.io/badge/Homepage-Apodex_AI-white"/></a>
   <a href="https://platform.apodex.ai"><img alt="API" src="https://img.shields.io/badge/API-Apodex_1.1-1783ff"/></a>
+  <br>
   <a href="https://huggingface.co/collections/apodex"><img alt="Hugging Face" src="https://img.shields.io/badge/🤗%20Hugging_Face-Apodex_AI-ffc107"/></a>
   <a href="https://discord.gg/TDJA59TCng"><img alt="Discord" src="https://img.shields.io/badge/Discord-Apodex_AI-5865F2"/></a>
   <a href="https://x.com/Apodex_AI"><img alt="X" src="https://img.shields.io/badge/X-@Apodex__AI-000000?logo=x&logoColor=white"/></a>


### PR DESCRIPTION
## Summary

- add vertical separation below the Apodex logo
- split the README badges into two rows for a less crowded header

## Validation

- `git diff --check`