### PR TITLE
ci: drop anonymous-pull check from docker smoke test

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,20 +59,9 @@ jobs:
         run: |
           image="$(printf '%s\n' "$IMAGE_TAGS" | head -n 1)"
           test -n "$image"
+          # The package is private by org policy, so this pull relies on the
+          # ghcr.io login established earlier in the job. Do not add an
+          # anonymous-pull check here: it cannot succeed.
           docker pull "$image"
           docker run --rm "$image" --version
           docker run --rm "$image" python tools/import_smoke.py --stage 2
-
-          # GHCR can briefly return 401 for anonymous requests immediately after
-          # a public image is pushed. Verify public access separately with retries.
-          docker logout ghcr.io
-          for attempt in 1 2 3 4 5 6; do
-            if docker pull "$image"; then
-              exit 0
-            fi
-            if [ "$attempt" -eq 6 ]; then
-              echo "::error::Published image is not anonymously pullable: $image"
-              exit 1
-            fi
-            sleep $((attempt * 5))
-          done

--- a/apodex/tests/test_deployment_config.py
+++ b/apodex/tests/test_deployment_config.py
@@ -295,12 +295,15 @@ def test_publish_workflow_uses_canonical_image_and_runtime_smoke() -> None:
 
     assert f"images: {IMAGE}" in workflow
     assert "type=sha,format=long" in workflow
-    assert "docker logout ghcr.io" in workflow
-    assert workflow.index('docker pull "$image"') < workflow.index("docker logout ghcr.io")
-    assert "for attempt in 1 2 3 4 5 6" in workflow
-    assert "Published image is not anonymously pullable" in workflow
+    assert 'docker pull "$image"' in workflow
     assert 'docker run --rm "$image" --version' in workflow
     assert "python tools/import_smoke.py --stage 2" in workflow
+
+    # The published package is private by org policy, so the smoke test can only
+    # pull while the job still holds its ghcr.io login. An anonymous-pull check
+    # can never pass here; keep it from being reintroduced.
+    assert "docker logout ghcr.io" not in workflow
+    assert "anonymously pullable" not in workflow
 
 
 def test_user_docs_use_the_published_registry_name() -> None:


### PR DESCRIPTION
## Problem

Every `Publish Docker Image` run since the initial release has failed — 6 for 6. But the failure moved: the original `denied: permission_denied: read_package` was a GHCR package-ownership issue (the `frontieragent` package was created by the old repo, since renamed to `FrontierAgentInternal`, so this repo's `GITHUB_TOKEN` had no access). That has been fixed out-of-band by granting this repo Admin access in the package's *Manage Actions access* settings.

With that resolved, build and push now succeed. The remaining failure is the last step:

```
Removing login credentials for ghcr.io
Error response from daemon: Head "https://ghcr.io/v2/apodexai/frontieragent/manifests/main": unauthorized   (x6)
##[error]Published image is not anonymously pullable: ghcr.io/apodexai/frontieragent:main
```

The package is **private** by org policy. The `docker logout` + anonymous `docker pull` block asserts the opposite, so it can never pass — the retry loop just burns ~2 minutes before failing a job whose image was already published successfully.

## Change

Drop the anonymous-pull assertion. The checks that actually validate the image are kept, and still run while the job holds its `ghcr.io` login:

- `docker pull` the published tag
- `docker run --rm "$image" --version`
- `docker run --rm "$image" python tools/import_smoke.py --stage 2`

A comment records why the anonymous check must not be added back, so it does not get "restored" as an apparent omission later.

## Note

The repository is public but the image package is private, so external users cannot `docker pull` the published image. That is a policy decision and is left alone here — worth confirming it matches what the README tells users to do.