### PR TITLE
docs: tidy README header and point Tech Report at arXiv

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 </div>
 <hr>
 <br>
-<div align="center" style="line-height:1">
-
 
 <div align="center">
   <a href="https://www.apodex.ai"><img alt="Online Service" src="https://img.shields.io/badge/🤖%20Online_Service-Apodex_1.1-1783ff"/></a>

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
     <img src="./assets/apodex_logo.jpeg" width="30%" alt="Apodex">
   </picture>
 </div>
-
----
-
+<hr>
 <br>
+<div align="center" style="line-height:1">
+
 
 <div align="center">
   <a href="https://www.apodex.ai"><img alt="Online Service" src="https://img.shields.io/badge/🤖%20Online_Service-Apodex_1.1-1783ff"/></a>
@@ -18,10 +18,10 @@
   <a href="https://x.com/Apodex_AI"><img alt="X" src="https://img.shields.io/badge/X-@Apodex__AI-000000?logo=x&logoColor=white"/></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/License-Apache_2.0-blue"/></a>
 </div>
-
+<br>
 <p align="center">
   <b><a href="https://www.apodex.com/blog/apodex-1.1-scaling-agentic-intelligence-for-complex-work">Tech Blog</a></b> ·
-  <b><a href="https://www.apodex.com/pdf/20260824">Tech Report</a></b>
+  <b><a href="https://arxiv.org/abs/2608.23283">Tech Report</a></b>
 </p>
 
 # FrontierAgent


### PR DESCRIPTION
## Summary
- Replace the `---` rule under the logo with `<hr>` and adjust the header spacing/badge block
- Point the **Tech Report** link at the arXiv page (`arxiv.org/abs/2608.23283`) instead of the hosted PDF

## Test plan
- [ ] Visually check the rendered README header on GitHub
- [ ] Confirm the Tech Report link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)