### PR TITLE
docs: update citations and add Star History

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -2,7 +2,7 @@ name: Update Star History
 
 on:
   schedule:
-    - cron: "17 3 * * *"
+    - cron: "17 */2 * * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,94 @@
+name: Update Star History
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: star-history
+  cancel-in-progress: true
+
+jobs:
+  render:
+    name: Render charts
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Render light and dark charts
+        uses: narayann7/star-history-action@c2061675dacbf6f35d116e556015b8905843387f # v1.0.4
+        with:
+          repos: ${{ github.repository }}
+          output-dir: assets/star-history
+          token: ${{ github.token }}
+          themes: light,dark
+          update-readme: false
+          commit: false
+
+      - name: Upload charts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: star-history-charts
+          path: |
+            assets/star-history/star-history-light.svg
+            assets/star-history/star-history-dark.svg
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish charts
+    needs: render
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Download charts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: star-history-charts
+          path: ${{ runner.temp }}/star-history/assets/star-history
+
+      - name: Validate generated files
+        shell: bash
+        run: |
+          set -euo pipefail
+          chart_dir="${RUNNER_TEMP}/star-history/assets/star-history"
+          test -s "${chart_dir}/star-history-light.svg"
+          test -s "${chart_dir}/star-history-dark.svg"
+          test "$(find "${chart_dir}" -type f | wc -l)" -eq 2
+          test -z "$(find "${chart_dir}" -type l -print -quit)"
+          grep -q '<svg' "${chart_dir}/star-history-light.svg"
+          grep -q '<svg' "${chart_dir}/star-history-dark.svg"
+          if grep -Eiq '<script|<foreignObject|on[a-z]+=' "${chart_dir}"/*.svg; then
+            echo "Refusing to publish unsafe SVG content." >&2
+            exit 1
+          fi
+
+      - name: Publish isolated chart branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          export GIT_INDEX_FILE="${RUNNER_TEMP}/star-history.index"
+          export GIT_WORK_TREE="${RUNNER_TEMP}/star-history"
+          git read-tree --empty
+          git add -f assets/star-history/star-history-light.svg \
+            assets/star-history/star-history-dark.svg
+          tree="$(git write-tree)"
+          commit="$(printf '%s\n' 'chore: update star history chart [skip ci]' | git commit-tree "${tree}")"
+          git push --force origin "${commit}:refs/heads/star-history"

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -25,12 +25,42 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Verify Star History token
+        shell: bash
+        env:
+          STAR_HISTORY_TOKEN: ${{ secrets.STAR_HISTORY_TOKEN }}
+        run: |
+          if [ -z "${STAR_HISTORY_TOKEN}" ]; then
+            echo "STAR_HISTORY_TOKEN is not configured." >&2
+            exit 1
+          fi
+
+      - name: Verify stargazers API access
+        shell: bash
+        env:
+          STAR_HISTORY_TOKEN: ${{ secrets.STAR_HISTORY_TOKEN }}
+        run: |
+          set -euo pipefail
+          status="$(curl --silent --show-error \
+            --output "${RUNNER_TEMP}/stargazers-response.json" \
+            --write-out '%{http_code}' \
+            --header 'Accept: application/vnd.github.star+json' \
+            --header "Authorization: Bearer ${STAR_HISTORY_TOKEN}" \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/stargazers?per_page=1")"
+          if [ "${status}" != '200' ]; then
+            echo "Stargazers API returned HTTP ${status}." >&2
+            python3 -c 'import json,sys; data=json.load(open(sys.argv[1])); print(data.get("message", "Unknown GitHub API error"))' \
+              "${RUNNER_TEMP}/stargazers-response.json"
+            exit 1
+          fi
+
       - name: Render light and dark charts
         uses: narayann7/star-history-action@c2061675dacbf6f35d116e556015b8905843387f # v1.0.4
         with:
           repos: ${{ github.repository }}
           output-dir: assets/star-history
-          token: ${{ github.token }}
+          token: ${{ secrets.STAR_HISTORY_TOKEN }}
           themes: light,dark
           update-readme: false
           commit: false

--- a/README.md
+++ b/README.md
@@ -379,10 +379,10 @@ Apache 2.0 — see [LICENSE](./LICENSE).
 
 ## Star History
 
-<a href="https://star-history.com/#ApodexAI/FrontierAgent&Date">
+<a href="https://github.com/ApodexAI/FrontierAgent/stargazers">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ApodexAI/FrontierAgent&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ApodexAI/FrontierAgent&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=ApodexAI/FrontierAgent&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ApodexAI/FrontierAgent/star-history/assets/star-history/star-history-dark.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ApodexAI/FrontierAgent/star-history/assets/star-history/star-history-light.svg" />
+    <img alt="Star History Chart" src="https://raw.githubusercontent.com/ApodexAI/FrontierAgent/star-history/assets/star-history/star-history-light.svg" />
   </picture>
 </a>

--- a/README.md
+++ b/README.md
@@ -340,10 +340,26 @@ with model cards and serving guidance.
 Cite the current release:
 
 ```bibtex
-@techreport{apodex11,
-  title  = {Apodex-1.1: Scaling Agentic Intelligence for Complex Work},
-  author = {Apodex Team},
-  year   = {2026}
+@article{apodex11,
+  title         = {Apodex-1.1: Scaling Agentic Intelligence for Complex Work},
+  author        = {Apodex Team},
+  year          = {2026},
+  eprint        = {2608.23283},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.AI},
+  url           = {https://arxiv.org/abs/2608.23283}
+}
+```
+
+```bibtex
+@misc{frontierchallenge,
+  title        = {FrontierChallenge: Evaluating Scientific Workflow Completion},
+  author       = {Su, Liangcai and Feng, Zhaopeng and Chen, Zhuo and Zhang, Zhen
+                  and Lin, Xiang and Li, Ruilin and Zhang, Handuo and Wang, Ning
+                  and Wen, Kailong and Guo, Yueqi and Xing, Feng and Guo, Yiling
+                  and Qian, Chenxiong and Du, Simon Shaolei and Bing, Lidong
+                  and Wang, Xinyu},
+  year         = {2026}
 }
 ```
 
@@ -360,3 +376,13 @@ For work that refers specifically to the previous generation:
 ## License
 
 Apache 2.0 — see [LICENSE](./LICENSE).
+
+## Star History
+
+<a href="https://star-history.com/#ApodexAI/FrontierAgent&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ApodexAI/FrontierAgent&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ApodexAI/FrontierAgent&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=ApodexAI/FrontierAgent&type=Date" />
+  </picture>
+</a>


### PR DESCRIPTION
## Summary

- update the Apodex-1.1 citation with arXiv metadata
- add the FrontierChallenge citation
- replace the restricted hosted Star History API with self-hosted light and dark SVG charts
- refresh charts every two hours and publish them to an isolated `star-history` branch

## Security and maintenance

- read stargazer history with the approved, repository-scoped `STAR_HISTORY_TOKEN` Actions secret
- pin all top-level Actions to commit SHAs
- keep chart publication isolated from `main` and validate SVG output before publishing
- reserve the workflow's `contents: write` permission for the native Git publishing job

## Validation

- successful end-to-end Actions preview: token preflight, chart rendering, artifact transfer, SVG validation, and isolated branch publication
- public light and dark SVG URLs return HTTP 200
- YAML parse check
- `git diff --check`

The `star-history` branch has been seeded by the preview run. After merge, the two-hour schedule will keep the chart current.