### PR TITLE
Link FrontierChallenge paper on arXiv

### DIFF
--- a/benchmarks/frontierchallenge/site/index.html
+++ b/benchmarks/frontierchallenge/site/index.html
@@ -30,7 +30,7 @@
 
       <section class="resource-links" aria-label="Project resources">
         <a href="https://github.com/ApodexAI/FrontierAgent/tree/main/benchmarks/frontierchallenge" target="_blank" rel="noreferrer"><span>GitHub</span><i aria-hidden="true">↗</i></a>
-        <a href="#" aria-label="Paper link placeholder"><span>Paper</span><i aria-hidden="true">↗</i></a>
+        <a href="https://arxiv.org/abs/2608.24979" target="_blank" rel="noreferrer"><span>Paper</span><i aria-hidden="true">↗</i></a>
         <a href="https://huggingface.co/datasets/apodex/FrontierChallenge" target="_blank" rel="noreferrer"><span>Hugging Face</span><i aria-hidden="true">↗</i></a>
       </section>
 


### PR DESCRIPTION
## Summary
- replace the website Paper placeholder with the published arXiv page
- open the paper link in a new tab with the same external-link behavior as the other resource buttons

Paper: https://arxiv.org/abs/2608.24979