### PR TITLE
compat: treat natural no_tool finish as a complete run

### DIFF
--- a/apodex/task_runner.py
+++ b/apodex/task_runner.py
@@ -564,6 +564,7 @@ class TaskRunnerMixin:
             stopped_by,
             answer_status=str(state.get("answer_status") or ""),
             answer_source=str(state.get("final_answer_source") or ""),
+            no_tool_is_complete=True,
         )
         if complete:
             self.r.final(

--- a/workflows/stateful_react_agent/_runtime.py
+++ b/workflows/stateful_react_agent/_runtime.py
@@ -116,7 +116,7 @@ def render_system_prompt_notes(
 # mid-token. Without the rescue that fragment IS the answer — which is how a run
 # whose visible output was "The shell ate my `" scored zero.
 _GRACEFUL_FINAL_STOP_REASONS = frozenset({
-    "max_turns", "context_limit_reached", "response_truncated",
+    "max_turns", "context_limit_reached", "response_truncated", "no_tool",
 })
 
 # Abnormal / infra terminations: the LLM endpoint exhausted retries


### PR DESCRIPTION
## Summary
Two parity gaps break the stateful react workflow for OpenAI-compatible models that end a task with a plain-text answer instead of a final tool call. Reproduced with a local Qwen3.5-family endpoint (qwen3.8-27b via Ollama `/v1`).

## Changes
1. `workflows/stateful_react_agent/_runtime.py` — add `no_tool` to `_GRACEFUL_FINAL_STOP_REASONS` so `force_final_answer()` rescue runs when the loop ends naturally after the model has already produced its answer.
2. `apodex/task_runner.py` — pass `no_tool_is_complete=True` in the native-workflow completion check, matching the generic-loop path (which already passes it).

## Verification
- Before: local qwen3.8-27b-fast completes the task (reads input, writes deliverable content) but the run is reported as `run incomplete · stopped_by=no_tool · partial output was not saved as a final report`.
- After: same run completes and the final report is rendered/saved.

## Notes
- Generic loop already passes `no_tool_is_complete=True`; this makes the native workflow consistent.
- No behavior change for workflows that finish via explicit final-answer tools.