### PR TITLE
fix(reader_xlsx): add missing `import subprocess` (recalc silently disabled)

### DIFF
--- a/plugins/tools/_reader_xlsx.py
+++ b/plugins/tools/_reader_xlsx.py
@@ -15,6 +15,7 @@ import datetime as _dt
 import os
 import re
 import shutil
+import subprocess
 import tempfile
 import xml.etree.ElementTree as _ET
 import zipfile


### PR DESCRIPTION
### Problem

`plugins/tools/_reader_xlsx.py` calls `subprocess.run(...)` in `_x_recalc_copy` (lines 133 and 149), but the module never imports `subprocess`:

```python
import datetime as _dt
import os
import re
import shutil
import tempfile
import xml.etree.ElementTree as _ET
import zipfile
```

Because the entire body of `_x_recalc_copy` is wrapped in `try: ... except Exception: return None`, the `NameError: name 'subprocess' is not defined` is **swallowed silently** rather than crashing.

### Impact

`_x_recalc_copy` first checks `if not shutil.which("soffice"): return None`, so the `subprocess.run` calls are only reached when LibreOffice **is** installed. In exactly that case, the call raises `NameError`, is caught, and returns `None`. The caller then does:

```python
new = _x_recalc_copy(path)
if new:
    ... # recalc done
else:
    mark_uncached = True
    head.append("`recalc: soffice unavailable; empty formula caches marked uncached`")
```

So on any machine where `soffice` **is** available, the formula-recalc feature silently reports "soffice unavailable" and never recalculates empty formula caches — the feature is effectively dead.

### Fix

Add the missing `import subprocess`. One line, no behavior change beyond letting the recalc path run as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
